### PR TITLE
:bug: add indexer dependency for smart_rule index

### DIFF
--- a/etc/indexer.xml
+++ b/etc/indexer.xml
@@ -12,4 +12,10 @@
         <title translate="true">Smart Category Product Rule</title>
         <description translate="true">Indexed smart category product/rule association</description>
     </indexer>
+
+    <indexer id="catalog_category_product">
+        <dependencies>
+            <indexer id="smartcategory_product"/>
+        </dependencies>
+    </indexer>
 </config>


### PR DESCRIPTION
add indexer dependency for the category_product index. the category_product index should be dependant on the smartcategory index as it will generate new assignment entries