### PR TITLE
:bug: invalidate index when row/list should be indexed and index is set to scheduled update

### DIFF
--- a/Model/Indexer/Product/ProductRuleProcessor.php
+++ b/Model/Indexer/Product/ProductRuleProcessor.php
@@ -17,4 +17,23 @@ class ProductRuleProcessor extends AbstractProcessor
      * Indexer id
      */
     const INDEXER_ID = 'smartcategory_product';
+
+    public function reindexRow($id, $forceReindex = false)
+    {
+        if (!$forceReindex && $this->isIndexerScheduled()) {
+            $this->getIndexer()->invalidate();
+            return;
+        }
+        parent::reindexRow($id, $forceReindex);
+    }
+
+    public function reindexList($ids, $forceReindex = false)
+    {
+        if (!$forceReindex && $this->isIndexerScheduled()) {
+            $this->getIndexer()->invalidate();
+        }
+        parent::reindexList($ids, $forceReindex);
+    }
+
+
 }


### PR DESCRIPTION
the index is not gonna be rebuilt as the default behavior for scheduled indizes is to ignore row/list index commands, therfore just invalidate the indizes to reindex afterwards