### PR TITLE
:bug: fix problem when adding configurable simple products to the rule

### DIFF
--- a/Model/Indexer/IndexBuilder.php
+++ b/Model/Indexer/IndexBuilder.php
@@ -296,8 +296,8 @@ class IndexBuilder
         $postedProducts = $this->getPostedProductData($rule->getId()) ?: [];
         $matchingProducts = $rule->getMatchingProductIds();
 
-        $deleteIds = array_diff($postedProducts, $matchingProducts);
-        $insertIds = array_diff($matchingProducts, $postedProducts);
+        $deleteIds = array_diff_key($postedProducts, $matchingProducts);
+        $insertIds = array_diff_key($matchingProducts, $postedProducts);
 		
         if (0 < count($deleteIds)) {
 			$this->cleanByIds($rule->getId(), array_keys($deleteIds));


### PR DESCRIPTION
array_diff just compares the values of both arrays, but those will just contains 1 for every value. therefore change to array_diff_key which are the product_ids that are selected for the smartcategory assignment